### PR TITLE
Problem with multipleSeparator == ', '

### DIFF
--- a/jquery.autocomplete.js
+++ b/jquery.autocomplete.js
@@ -224,7 +224,7 @@ $.Autocompleter = function(input, options) {
 		previousValue = v;
 		
 		if ( options.multiple ) {
-			var words = trimWords($input.val());
+			var words = $input.val().split(options.multipleSeparator);
 			if ( words.length > 1 ) {
 				var seperator = options.multipleSeparator.length;
 				var cursorAt = $(input).selection().start;


### PR DESCRIPTION
Hi, Alfonso!

I found a little bug, when the plugin used with the following settings: {multiple: true, multipleSeparator: ', '}
Basically, it doesn't play well with redundant spaces. Steps to reproduce:

1) save the following html into the root directory of the project:

```
<html>
  <head>
    <script type='text/javascript' src='lib/jQuery-1.4.4.min.js'></script>
    <script type='text/javascript' src='jquery.autocomplete.js'></script>
    <script type="text/javascript">
      $().ready(function() {
        $('#ac').autocomplete(['Option', 'Another Option'], {multiple: true, multipleSeparator: ', '});
      });
    </script>
    <link rel="stylesheet" type="text/css" href="jquery.autocomplete.css">
  </head>

  <body>
  <form>
    <input id='ac'>
  </form>
  <body>
</html>
```

2) Type "Opt", choose "Option"
3) **Type space several times**
4) Type "Ano", choose "Another Option"

Expected result: "Option, Another Option"
Actual result: "Option, ano"
