### PR TITLE
account for retooled key events handling in newer Opera

### DIFF
--- a/jquery.autocomplete.js
+++ b/jquery.autocomplete.js
@@ -94,8 +94,8 @@ $.Autocompleter = function(input, options) {
 		}
 	});
 	
-	// only opera doesn't trigger keydown multiple times while pressed, others don't work with keypress at all
-	$input.bind(($.browser.opera ? "keypress" : "keydown") + ".autocomplete", function(event) {
+	// older versions of opera don't trigger keydown multiple times while pressed, others don't work with keypress at all
+	$input.bind(($.browser.opera && !'KeyboardEvent' in window) ? "keypress" : "keydown") + ".autocomplete", function(event) {
 		// a keypress means the input has focus
 		// avoids issue where input had focus before the autocomplete was applied
 		hasFocus = 1;


### PR DESCRIPTION
This will ensure that this plugin continues to work once key event changes land in Opera Next. Thanks!
