### PR TITLE
Prevent IE 11 from using document.selection

### DIFF
--- a/jquery.autocomplete.js
+++ b/jquery.autocomplete.js
@@ -824,7 +824,7 @@ $.fn.selection = function(start, end) {
 		});
 	}
 	var field = this[0];
-	if ( field.createTextRange ) {
+	if ( document.selection ) {
 		var range = document.selection.createRange(),
 			orig = field.value,
 			teststring = "<->",


### PR DESCRIPTION
For IE 11, document.selection is no longer supported. See 
http://msdn.microsoft.com/en-us/library/ie/ms535869(v=vs.85).aspx 
for details. 

Updated condition so IE 11 uses selectionStart and 
selectionEnd similar to Chrome and Firefox.

Versions of IE < 11 are unaffected.

![image](https://f.cloud.github.com/assets/516155/2479788/b093e6ec-b0a2-11e3-810a-1a395c515226.png)
