### PR TITLE
Bug of click on IE

### DIFF
--- a/jquery.autocomplete.js
+++ b/jquery.autocomplete.js
@@ -238,7 +238,7 @@ $.Autocompleter = function(input, options) {
 					}
 					progress += seperator;
 				});
-				words[words.length-1] = v;
+				words[words.length-1] = v; 
 				// TODO this should set the cursor to the right position, but it gets overriden somewhere
 				//$.Autocompleter.Selection(input, progress + seperator, progress + seperator);
 				v = words.join( options.multipleSeparator );


### PR DESCRIPTION
Hi, i just altered the file "jquery.autocomplete.js" for you guys to check.
I had a prob when clicking on the option on IE, because the option will not fill the input. Instead the behaviour was replacing the current value with a new value and a part of the current target filling value on the input.
