### PR TITLE
Add showNoResults option

### DIFF
--- a/docs/subs/autocomplete_options.html
+++ b/docs/subs/autocomplete_options.html
@@ -333,6 +333,7 @@
 		<tr class="option"><th>scroll</th><td class="type">Boolean</td><td class="default"><b>Default:</b> <span>true </span></td></tr><tr><td colspan="3" class="desc">Whether to scroll when more results than configured via scrollHeight are available.</td></tr> 
 		<tr class="option"><th>scrollHeight</th><td class="type">Number</td><td class="default"><b>Default:</b> <span>180</span></td></tr><tr><td colspan="3" class="desc">height of scrolled autocomplete control in pixels</td></tr> 
 		<tr class="option"><th>selectFirst</th><td class="type">Boolean</td><td class="default"><b>Default:</b> <span>true</span></td></tr><tr><td colspan="3" class="desc">If this is set to true, the first autocomplete value will be automatically selected on tab/return, even if it has not been handpicked by keyboard or mouse action. If there is a handpicked (highlighted) result, that result will take precedence.</td></tr> 
+		<tr class="option"><th>showNoResults</th><td class="type">Boolean</td><td class="default"><b>Default:</b> <span>true</span></td></tr><tr><td colspan="3" class="desc">Whether to show "No Records." message when there are no matching results. Setting this to false can help when selectFirst is true and mustMatch is false.</td></tr> 
 		<tr class="option"><th>width</th><td class="type">Number</td><td class="default"><b>Default:</b> <span>width of the input element</span></td></tr><tr><td colspan="3" class="desc">Specify a custom width for the select box.</td></tr> 
 		</p><p><br /> 
 		</tbody></table></div> 

--- a/jquery.autocomplete.js
+++ b/jquery.autocomplete.js
@@ -22,7 +22,7 @@ $.fn.extend({
 			data: isUrl ? null : urlOrData,
 			delay: isUrl ? $.Autocompleter.defaults.delay : 10,
 			max: options && !options.scroll ? 10 : 150,
-			noRecord: "No Records."
+			noRecord: options && options.showNoResults ? "No Records." : ""
 		}, options);
 
 		// if highlight is set to false, replace it with a do-nothing function


### PR DESCRIPTION
Whether to show "No Records." message when there are no matching
results. Setting this to false can help when selectFirst is true and
mustMatch is false.